### PR TITLE
added scope to automove

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ var defaults = {
   //   - reposition: 'viewport'
   // - default/undefined => on a position event for any node (not as efficient...)
   when: undefined
+
+  // specify a set of nodes over which the rule may apply. This is useful for large graphs, 
+  // where only a small, known subset of nodes may be affected by a given automove-rule. 
+  // - a collection of nodes
+  // - default/undefined => all nodes in graph
+  scope: undefined
 };
 
 var options = defaults;

--- a/cytoscape-automove.js
+++ b/cytoscape-automove.js
@@ -221,18 +221,25 @@
     rules = rules != null ? rules : scratch.rules;
 
     cy.batch(function(){ // batch for performance
-      for( var i = 0; i < nodes.length; i++ ){
-        var node = nodes[i];
+      for(var i = 0; i < rules.length; i++){
+        var rule = rules[i];
+        if(rule.destroyed || !rule.enabled){ break; } // ignore destroyed rules b/c user may use custom when()
 
-        for( var j = 0; j < rules.length; j++ ){
-          var rule = rules[j];
+        // If this rule has a limited scope, only iterate over nodes within scope, 
+        // else - apply rule across -all- nodes in graph.
+        if(rule.scope){
+          var nodes = rule.scope;
+        }else{
+          var nodes = cy.nodes();           
+        }
 
-          if( rule.destroyed || !rule.enabled ){ break; } // ignore destroyed rules b/c user may use custom when()
+        for(var j = 0; j < nodes.length; j++){
+          var node = nodes[j];
 
           if( !rule.matches(node) ){ continue; }
-
-          var pos = node.position();
-          var newPos = rule.getNewPos( node );
+        
+          var pos = node.position(); 
+          var newPos = rule.getNewPos( node ); 
           var newPosIsDiff = pos.x !== newPos.x || pos.y !== newPos.y;
 
           if( newPosIsDiff ){ // only update on diff for perf
@@ -240,7 +247,8 @@
           }
         }
       }
-    });
+    })
+
   };
 
   // registers the extension on a cytoscape lib ref


### PR DESCRIPTION
We're using automove in a fairly large graph where each automove-rule only affects a very small and known set of other nodes. Since the default is to check all nodes in graph, this absolutely slays our performance when moving nodes. 

I've extended rules to also support a scope-parameter, which limits the set of nodes checked for applicability. I've also switched the inner/outer loops in `update` since there's no need to iterate the entire node-set if a given rule is destroyed or `!enabled`.

Currently, it expects a collection but if you think this is a good idea in general - I'll extend it to support selector and function as well. 