### PR TITLE
constrain the node location out of the box

### DIFF
--- a/src/automove.js
+++ b/src/automove.js
@@ -79,7 +79,10 @@ let getRepositioner = function( rule, cy ){
   } else if( r === 'drag' ){
     return dragAlong( rule );
   } else if( isObject( r ) ){
-    return boxPosition( r );
+    if(r['type'] == "inside")
+      return boxPosition( r["pos"] );
+    else if(r['type'] == "outside")
+      return OboxPosition( r["pos"] );
   } else {
     return r;
   }
@@ -146,6 +149,36 @@ let constrainInBox = function( node, bb ){
 let boxPosition = function( bb ){
   return function( node ){
     return constrainInBox( node, bb );
+  };
+};
+
+let Oconstrain = function( val, min, max ){
+  let mid = (min+max)/2;
+  if(val>min && val<max){
+    return val>mid? max : min;
+  }
+  return val;
+};
+
+let OconstrainInBox = function( node, bb ){
+  let pos = node.position();
+  let x = Oconstrain( pos.x, bb.x1, bb.x2 );
+  let y = Oconstrain( pos.y, bb.y1, bb.y2 );
+
+  if(x!=pos.x && y!=pos.y){
+    if(Math.abs(pos.x-x)<Math.abs(pos.y-y)){
+      pos.x = x;
+    }else{
+      pos.y = y;
+    }
+  }
+
+  return pos;
+};
+
+let OboxPosition = function( bb ){
+  return function( node ){
+    return OconstrainInBox( node, bb );
   };
 };
 


### PR DESCRIPTION
Hi, I added the feature that you can constrain that a node should always stay out of the box. The way to specify the box is same with the rule to constrain within the box, as {x1: number, x2: number, y1: number, y2: number}. But to differentiate those two kinds I added another key-value pair "type".

Now the specification of rule is:
1. To constrain within the box:
`{"type": "inside", "pos": {x1,x2,y1,y2}}`

2. To constrain out of the box:
`{"type": "outside", "pos": {x1,x2,y1,y2}}`

Hope it would be useful :)