### PR TITLE
removed unused "bindings" array

### DIFF
--- a/src/automove.js
+++ b/src/automove.js
@@ -42,12 +42,8 @@ let getEleMatchesSpecFn = function( spec ){
   }
 };
 
-let bindings = [];
-
 let bind = function( cy, events, selector, fn ){
   let b = { cy: cy, events: events, selector: selector || 'node', fn: fn };
-
-  bindings.push( b );
 
   cy.on( b.events, b.selector, b.fn );
 


### PR DESCRIPTION
This array is being populated but totally unused.
Irrelevant items are never removed from the array, causing possible memory leaks.
Currently it seems to be the best idea just to remove the array and its population from the code.